### PR TITLE
Fix SampleProfile validation against profile schema

### DIFF
--- a/profiles/RedfishInteroperabilityProfile.v1_8_0.json
+++ b/profiles/RedfishInteroperabilityProfile.v1_8_0.json
@@ -426,7 +426,7 @@
             "description": "An array of URI references to which the `ReadRequirement` and `WriteRequirement` are applied.  The URI values shall follow the resource URI pattern definition specified in the Redfish Specification.",
             "items": {
                 "type": "string",
-                "format": "uri-reference"
+                "format": "uri-template"
             }
         },
         "ReadRequirement": {
@@ -578,7 +578,7 @@
         },
         "Repository": {
             "type": "string",
-            "format": "uri-reference",
+            "format": "uri-template",
             "description": "A URI providing the location of the repository which contains the JSON files to be included.  The filenames of the JSON files contained in the repository are expected to follow the Redfish message registry filename conventions.  If absent, the repository location shall be the Redfish registry repository (http://redfish.dmtf.org/registries)."
         }
     }

--- a/profiles/SampleProfile.json
+++ b/profiles/SampleProfile.json
@@ -1,5 +1,5 @@
 {
-    "SchemaDefinition": "RedfishInteroperabilityProfile.v1_7_0",
+    "SchemaDefinition": "RedfishInteroperabilityProfile.v1_8_0",
     "ProfileName": "Anchovy",
     "ProfileVersion": "1.0.3",
     "Purpose": "This is a sample Redfish Interoperability profile.",
@@ -80,9 +80,9 @@
                 },
                 "IndicatorLED": {
                     "ReadRequirement": "Recommended",
+                    "ReplacedByProperty": "LocationIndicatorActive",
                     "ConditionalRequirements": [{
                         "Purpose": "Physical systems must have a writable IndicatorLED, but prefer LocationIndicatorActive.",
-                        "ReplacedByProperty": "LocationIndicatorActive",
                         "CompareProperty": "SystemType",
                         "CompareType": "AnyOf",
                         "CompareValues": ["Physical"],
@@ -108,7 +108,7 @@
         },
         "EthernetInterface": {
             "UseCases": [{
-                    "UseCaseName": "Ethernet Interface on Manager (BMC)",
+                    "UseCaseTitle": "Ethernet Interface on Manager (BMC)",
                     "URIs": ["/redfish/v1/Managers/{ManagerId}/EthernetInterfaces/{EthernetInterfaceId}"],
                     "MinVersion": "1.9.0",
                     "ReadRequirement": "Mandatory",
@@ -124,8 +124,8 @@
                     }
                 },
                 {
-                    "UseCaseName": "Host System (OS) Ethernet Interfaces",
-                    "URIs": ["/redfish/v1/Systems/{ComputerSystemId}/EthernetInterfaces/{EthernetInterfaceId}", "/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkDeviceFunctions//{NetworkDeviceFunctionId}/EthernetInterfaces/{EthernetInterfaceId}"],
+                    "UseCaseTitle": "Host System (OS) Ethernet Interfaces",
+                    "URIs": ["/redfish/v1/Systems/{ComputerSystemId}/EthernetInterfaces/{EthernetInterfaceId}", "/redfish/v1/Chassis/{ChassisId}/NetworkAdapters/{NetworkAdapterId}/NetworkDeviceFunctions/{NetworkDeviceFunctionId}/EthernetInterfaces/{EthernetInterfaceId}"],
                     "MinVersion": "1.4.0",
                     "ReadRequirement": "Mandatory",
                     "PropertyRequirements": {
@@ -219,7 +219,9 @@
                     "ConditionalRequirements": [{
                         "CompareProperty": "TimeMachineModel",
                         "CompareType": "Equal",
-                        "CompareValue": "Delorean",
+                        "CompareValues": [
+                            "Delorean"
+                        ],
                         "ReadRequirement": "Mandatory",
                         "Comparison": "AnyOf",
                         "Values": ["None", "Recoverable", "Improbable"]


### PR DESCRIPTION
Hi, I am aware this is a read-only repo, this pull request is for the sake of ease of discussion. Feel free to close.

- Corrected implementation mistakes in SampleProfile
- Use uri-template (RFC6570) instead of uri-reference in schema: uri-reference does not allow for the curly braces used in Redfish Resource URI Patterns, making validation of wildcards currently impossible.
Redfish spec currently reinvents a simplified RFC6570 and should probably be changed to reference the RFC directly. In the meantime, it is better to be too lax than too strict in the profile schema.

Before: https://www.jsonschemavalidator.net/s/1874713z
After: https://www.jsonschemavalidator.net/s/uHytSMtk