### PR TITLE
Additional conditions for use cases

### DIFF
--- a/profiles/RedfishInteroperabilityProfile.v1_8_0.json
+++ b/profiles/RedfishInteroperabilityProfile.v1_8_0.json
@@ -186,16 +186,37 @@
                     "description": "Specifies a title or short name used to identify the resource use case.  This property is only present in resource use cases."
                 },
                 "UseCaseKeyProperty": {
-                    "type": "string",
-                    "description": "Specifies a property within the resource used by the UseCaseComparison to define the use case.  This property is only present in resource use cases."
+                    "$ref": "#/definitions/UseCaseKeyProperty"
                 },
                 "UseCaseKeyValues": {
-                    "description": "Specifies the values of `UseCaseKeyProperty` used to evaluate the `UseCaseComparison`.  This property is only present in resource use cases.",
-                    "$ref": "#/definitions/Values"
+                    "$ref": "#/definitions/UseCaseKeyValues"
                 },
                 "UseCaseComparison": {
-                    "description": "Specifies the type of comparison to perform using the `UseCaseKeyProperty` and the values contained in `UseCaseKeyValues`.  If the comparison is successful, this resource instance is covered by this resource use case.  This property is only present in resource use cases.",
-                    "$ref": "#/definitions/Comparison"
+                    "$ref": "#/definitions/UseCaseComparison"
+                },
+                "UseCaseAdditionalConditions": {
+                    "type": "array",
+                    "description": "An array of additional resource use case conditions, which must be validated in addition to the primary condition for the resource instance to be covered by the use case.  Additional use case conditions are always applied as if UseCaseType was `Normal`.  This property is only present in resource use cases.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "UseCaseKeyProperty": {
+                                "$ref": "#/definitions/UseCaseKeyProperty"
+                            },
+                            "UseCaseKeyValues": {
+                                "$ref": "#/definitions/UseCaseKeyValues"
+                            },
+                            "UseCaseComparison": {
+                                "$ref": "#/definitions/UseCaseComparison"
+                            }
+                        },
+                        "required": [
+                            "UseCaseKeyProperty",
+                            "UseCaseKeyValues",
+                            "UseCaseComparison"
+                        ],
+                        "additionalProperties": false
+                    }
                 },
                 "RequiredResourceProfile": {
                     "type": "object",
@@ -514,6 +535,18 @@
                 }
             },
             "additionalProperties": false
+        },
+        "UseCaseKeyProperty": {
+            "type": "string",
+            "description": "Specifies a property within the resource used by the UseCaseComparison to define the use case.  This property is only present in resource use cases."
+        },
+        "UseCaseKeyValues": {
+            "description": "Specifies the values of `UseCaseKeyProperty` used to evaluate the `UseCaseComparison`.  This property is only present in resource use cases.",
+            "$ref": "#/definitions/Values"
+        },
+        "UseCaseComparison": {
+            "description": "Specifies the type of comparison to perform using the `UseCaseKeyProperty` and the values contained in `UseCaseKeyValues`.  If the comparison is successful, this resource instance is covered by this resource use case.  This property is only present in resource use cases.",
+            "$ref": "#/definitions/Comparison"
         },
         "MinSupportValues": {
             "type": "array",


### PR DESCRIPTION
Hi, I am aware this is a read-only repo, this pull request is for the sake of ease of discussion. Feel free to close.

Adds a non-breaking change to make use cases support multiple conditions. This allows for more atomic profiles which better represent real-world feature requirements.

One such requirement could be that the BMC must expose the temperature of its host CPU. This can be modeled easily with a multi-conditional Sensor UseCase with the following conditions:
- PhysicalContext = CPU
- ReadingType = Temperature

This UseCase can then carry the specific requirements for such a sensor (update frequency, precision...).

A minimal profile containing such an atomic use case can then be used to represent the implementation requirements of a feature, and be shared between different products requirements (through inclusion with RequiredProfiles or RequiredResourceProfile).

Currently, a combination of UseCase + ConditionalRequirements can emulate the same feature, but is not practical:
- ConditionalRequirements have to be repeated for each property requirement (which there may be many of, e.g. thresholds in the case of a Sensor)
- It is impossible to subordinate a requirement to more than two conditions (one from the UseCase and one from the ConditionalRequirement)
- Readability is strongly impaired, since the conditions are split between the UseCase section and the ConditionalRequirements.

Note that while this is originally a vendor idea (Atos/Eviden firmware architecture team), interest for this change has been confirmed with client domain experts (Criteo hardware management team) at Prem'Day 2025 in Paris.